### PR TITLE
Fix installation for node >v0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "simple-log",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"dependencies": {
 		"node-syslog": "1.1.7"
 	},


### PR DESCRIPTION
After updating my node to v0.10, the installation of this package started failing. Updating its dependency node-syslog to 1.1.7 fixed it.

My node version:

```
$ node --version
v0.10.5
```

Failure:

```
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:267:23)
gyp ERR! stack     at ChildProcess.EventEmitter.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:784:12)
gyp ERR! System Linux 2.6.38-15-generic
gyp ERR! command "node" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /userdata/Documents/src/jquery/download.jqueryui.com/node_modules/simple-log/node_modules/node-syslog
gyp ERR! node -v v0.10.5
gyp ERR! node-gyp -v v0.9.5
gyp ERR! not ok 
npm ERR! node-syslog@1.1.6 install: `node-gyp rebuild`
npm ERR! `sh "-c" "node-gyp rebuild"` failed with 1
npm ERR! 
npm ERR! Failed at the node-syslog@1.1.6 install script.
```
